### PR TITLE
compiler: add json support, refactor output logic

### DIFF
--- a/compiler/compiler.cabal
+++ b/compiler/compiler.cabal
@@ -60,10 +60,12 @@ executable compiler
     , base
     , base16-bytestring
     , bytestring
+    , containers
     , directory
     , filepath
     , onchain
     , optparse-applicative
     , plutus-ledger-api
+    , text
   ghc-options:
     -rtsopts


### PR DESCRIPTION
The refactored logic is a little more verbose, but is more explicit about when to output a single stream vs multiple files, which I think improves the readability.