### PR TITLE
SSW-303: optimized math.pow2

### DIFF
--- a/lib/calculation/shared.ak
+++ b/lib/calculation/shared.ak
@@ -78,28 +78,28 @@ pub fn check_and_set_unique(uniqueness_flags: Int, index: Int) -> Int {
 /// This is a version of pow2 that's optimized for small batch sizes
 /// It performs a few more granular loop-unrolls, converging on the small lookup index faster
 /// This was presented by TxPipe, and squeezes out one extra escrow over math.pow2 for our typical order sizes
-pub fn small_pow2(index)  -> Int {
-  let a = #[1, 2, 4, 8, 16, 32, 64, 128]
-  if e < 8 {
-    builtin.index_bytearray(a, e)
-  } else if e < 16 {
-    // 2^8 * recurse
-    256 * builtin.index_bytearray(a, e - 8)
-  } else if e < 24 {
-    // 2^16 * recurse
-    65536 * builtin.index_bytearray(a, e - 16)
-  } else if e < 32 {
+pub fn small_pow2(exponent: Int)  -> Int {
+  let single_byte_powers = #[1, 2, 4, 8, 16, 32, 64, 128]
+  if exponent < 8 {
+    builtin.index_bytearray(single_byte_powers, exponent)
+  } else if exponent < 16 {
+    // 2^8 * table lookup
+    256 * builtin.index_bytearray(single_byte_powers, exponent - 8)
+  } else if exponent < 24 {
+    // 2^16 * table lookup
+    65536 * builtin.index_bytearray(single_byte_powers, exponent - 16)
+  } else if exponent < 32 {
     // 2^24 * recurse
-    16777216 * builtin.index_bytearray(a, e - 24)
-  } else if e < 40 {
+    16777216 * builtin.index_bytearray(single_byte_powers, exponent - 24)
+  } else if exponent < 40 {
     // 2^32 * recurse
-    4294967296 * builtin.index_bytearray(a, e - 32)
+    4294967296 * builtin.index_bytearray(single_byte_powers, exponent - 32)
   } else {
     // Otherwise we can fall back to the built in;
     // currently we can't fit more than 40 orders in a batch, but if
     // the protocol parameters get bumped, we don't want things to start failing!
     // When benchmarking, falling back to the builtin proved to be faster than recursing
     // unsure why that is!
-    math.pow2(e)
+    math.pow2(exponent)
   }
 }


### PR DESCRIPTION
Switches our recursive implementation of do_2_exp with a heavily optimized math.pow2 from the aiken standard library.

This version of the module didn't exist at the time, but uses a really clever trick to optimize. For the first 8 powers of 2, it uses a lookup into a bytestring to find the result, and only recurses in big leaps above 2^8.

In our benchmarks, this brings the number of orders per batch from 32 to 35!!

See: [SSW-303](https://github.com/txpipe-shop/sundae-swap/blob/968d16ca48055fa5dd70a34a0e1348224925f9ab/src/audit.typ#L214-L234)