### PR TITLE
SSW-301: Redundant orders parameters

### DIFF
--- a/lib/calculation/process.ak
+++ b/lib/calculation/process.ak
@@ -101,9 +101,7 @@ pub fn process_order(
   amortized_base_fee: Int,
   simple_fee: Int,
   strategy_fee: Int,
-  output: Output,
   outputs: List<Output>,
-  rest_outputs: List<Output>
 ) -> (PoolState, List<Output>, Int) {
   when details is {
     order.Strategy(signer) -> {
@@ -129,12 +127,11 @@ pub fn process_order(
         // reuse the code to calculate the result, but charge the higher fee
         strategy_fee,
         strategy_fee,
-        output,
         outputs,
-        rest_outputs,
       )
     }
     order.Swap(offer, min_received) -> {
+      expect [output, ..rest_outputs] = outputs
       // Make sure the scooper can only take up to the max fee the user has agreed to
       let fee = amortized_base_fee + simple_fee
       expect max_protocol_fee >= fee
@@ -151,6 +148,7 @@ pub fn process_order(
       (next, rest_outputs, fee)
     }
     order.Deposit(..) -> {
+      expect [output, ..rest_outputs] = outputs
       // Make sure the scooper can only take up to the max fee the user has agreed to
       let fee = amortized_base_fee + simple_fee
       expect max_protocol_fee >= fee
@@ -158,6 +156,7 @@ pub fn process_order(
       (next, rest_outputs, fee)
     }
     order.Withdrawal(..) -> {
+      expect [output, ..rest_outputs] = outputs
       // Make sure the scooper can only take up to the max fee the user has agreed to
       let fee = amortized_base_fee + simple_fee
       expect max_protocol_fee >= fee
@@ -167,6 +166,7 @@ pub fn process_order(
     }
     // order.Zap(..) -> do_zap(initial, input, datum)
     order.Donation(..) -> {
+      expect [output, ..rest_outputs] = outputs
       // Make sure the scooper can only take up to the max fee the user has agreed to
       let fee = amortized_base_fee + simple_fee
       expect max_protocol_fee >= fee
@@ -213,7 +213,6 @@ pub fn process_orders(
       expect [input_to_process, ..rest_of_input_list] = next_input_list
 
       let Input{ output_reference, output: order } = input_to_process
-      expect [output, ..rest_outputs] = outputs
 
       // make sure we only process scripts; this is so that our "order count" and "indexing set" logic is correct
       expect is_script(order.address.payment_credential)
@@ -243,9 +242,7 @@ pub fn process_orders(
         amortized_base_fee,
         simple_fee,
         strategy_fee,
-        output,
         outputs,
-        rest_outputs,
       )
 
       process_orders(


### PR DESCRIPTION
TxPipe pointed out that the `orders` parameter always equals `[order, ...rest_orders]`; this made the code slightly harder to reason about, without providing much material benefit.

At one point in time, this was an optimization, since `process_orders` needed the output and the tail of the list, and we could avoid destructuring twice. But since then, that logic has been moved into the singular `process_order` function, and so we can just do the destructure inside.

Of note, we only destructure on the 4 relevant branches; no need to destructure on strategy, because we're just calling the process function recursively to process whatever the actual strategy is.

Resolves: [SSW-301](https://github.com/txpipe-shop/sundae-swap/blob/968d16ca48055fa5dd70a34a0e1348224925f9ab/src/audit.typ#L195C1-L195C1)