### PR TITLE
Collect protocol fees on donations

### DIFF
--- a/lib/calculation/donation.ak
+++ b/lib/calculation/donation.ak
@@ -1,6 +1,6 @@
 use aiken/transaction.{NoDatum, Output}
 use aiken/transaction/credential.{Address, VerificationKeyCredential}
-use aiken/transaction/value.{Value}
+use aiken/transaction/value.{Value, ada_policy_id, ada_asset_name}
 use calculation/shared.{PoolState} as calc_shared
 use shared
 use sundae/multisig
@@ -21,6 +21,7 @@ pub fn do_donation(
   let remainder =
     shared.to_value(assets.1st)
       |> value.merge(shared.to_value(assets.2nd))
+      |> value.add(ada_policy_id, ada_asset_name, actual_protocol_fee)
       |> value.negate
       |> value.merge(input_value)
 
@@ -75,7 +76,7 @@ test donation() {
       protocol_fees: 2_000_000,
     }
   let input_value =
-    value.from_lovelace(1_000_000)
+    value.from_lovelace(3_500_000)
       |> value.add(rberry.1st, rberry.2nd, 1_000_000)
   let order =
     OrderDatum {

--- a/lib/calculation/process.ak
+++ b/lib/calculation/process.ak
@@ -316,7 +316,7 @@ test process_orders_test() {
       ScriptCredential(#"4af53ff4f054348ad825c692dd9db8f1760a8e0eacf9af9f99306513"),
       None,
     ),
-    value: value.from_lovelace(1_000_000)
+    value: value.from_lovelace(3_500_000)
       |> value.add(rberry.1st, rberry.2nd, 1_000_000),
     datum: InlineDatum(order_datum),
     reference_script: None,


### PR DESCRIPTION
I think initially we skipped collecting a fee on donations, because the user was doing a donation, so it felt weird to charge a fee.

However, the protocol isn't a liquidity provider for every pool, and needs to be compensated for the work it does to process the donation.

Without this, donations represent a DDOS attack, where the network could be flooded with cheap donations of a garbage token, and not have to pay the protocol to process them.