### PR TITLE
Resolve SSW-001 + SSW-002

### DIFF
--- a/validators/pool.ak
+++ b/validators/pool.ak
@@ -443,6 +443,13 @@ validator(settings_policy_id: PolicyId) {
           pool_output_datum.market_open <= pool_output_datum.fee_finalized,
         }
 
+        // Make sure that the pool output is paid into own_policy_id (the pool script, remember this is a multivalidator)
+        // and that one of the valid staking addresses is attached
+        expect pool_output.address.payment_credential == ScriptCredential(own_policy_id)
+        expect list.any(settings_datum.authorized_staking_keys, fn(a) {
+          pool_output.address.stake_credential == Some(Inline(a))
+        })
+
         // And then check each of the conditions above as the condition for minting
         and {
           coin_pair_ordering_is_canonical,

--- a/validators/tests/pool.ak
+++ b/validators/tests/pool.ak
@@ -586,7 +586,7 @@ fn mint_test_modify(
   modify_ref_output: fn(Output) -> Output,
   modify_datum: fn(Datum) -> Datum) -> Bool {
   let settings_policy_id = #"00000000000000000000000000000000000000000000000000000000"
-  let pool_address = script_address(pool_script_hash)
+  let pool_address = script_address(pool_script_hash) |> with_delegation_key(#"725011d2c296eb3341e159b6c5c6991de11e81062b95108c9aa024ad")
   let rberry_policy_id = #"9a9693a9a37912a5097918f97918d15240c92ab729a0b7c4aa144d77"
   let rberry_token_name = #"524245525259"
   let user_address =
@@ -631,7 +631,7 @@ fn mint_test_modify(
       |> add_asset_to_tx_output(ref_output_val)
       |> modify_ref_output
 
-  let poolMintRedeemer = CreatePool {
+  let pool_mint_redeemer = CreatePool {
     assets: ((#"", #""), (rberry_policy_id, rberry_token_name)),
     pool_output: 0,
     metadata_output: 2,
@@ -653,7 +653,7 @@ fn mint_test_modify(
     |> add_tx_output(lp_output)
     |> add_tx_output(pool_output)
 
-  let result = pool_validator.mint(settings_policy_id, poolMintRedeemer, ctx)
+  let result = pool_validator.mint(settings_policy_id, pool_mint_redeemer, ctx)
   result
 }
 
@@ -665,7 +665,13 @@ test mint_test() {
 test mint_test_wrong_address () fail {
   let minted = mint_test_modify(
     // change pool nft output address to destination that shouldn't be possible
-    fn (output) { Output{..output, address: from_verification_key(#"6af53ff4f054348ad825c692dd9db8f1760a8e0eacf9af9f99306513") }},
+    fn (output) {
+      Output{
+        ..output,
+        // TODO: move some of this stuff to constants?
+        address: from_verification_key(random_hash) |> with_delegation_key(#"725011d2c296eb3341e159b6c5c6991de11e81062b95108c9aa024ad")
+      }
+    },
     identity,
     identity,
     identity


### PR DESCRIPTION
Resolves SSW-001, where the pool token didn't have to be paid to the pool address.

Also resolves the accidental finding that we don't check for the pool output
address! Was discovered accidentally when we thought we fixed SSW-001 :sweat_smile: 

These likely crept in because we were focused on checking the staking credential, from a previous finding, but this would have been a very critical bug!