### PR TITLE
Optimization for count_orders

### DIFF
--- a/lib/shared.ak
+++ b/lib/shared.ak
@@ -117,6 +117,8 @@ pub fn is_script(credential: Credential) -> Bool {
 /// This is quite subtle, so see the note above
 pub fn count_orders(tx_inputs: List<Input>) -> Int {
   when tx_inputs is {
+    // Note: by using  -exact_non_order_script_inputs for the base case,
+    // it's equivalent to subtracting at the end
     [] -> -exact_non_order_script_inputs
     [input, ..rest] ->
       // The reason this is important is twofold:


### PR DESCRIPTION
Replace foldl with direct recursion and remove call to is_script. Also: new test for count_orders.

Tested with aiken v1.0.24-alpha+982eff4. 
Before:
  │ PASS [mem:   220233, cpu:   81559750] count_orders_test

After:
  │ PASS [mem:   205107, cpu:   75765469] count_orders_test
