### PR TITLE
Prevent execution of a deposit that would mint 0 LP tokens

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: aiken-lang/setup-aiken@v0.1.0
         with:
-          version: v1.0.24-alpha
+          version: v1.0.26-alpha
 
       - run: |
           # Run the tests

--- a/lib/calculation/deposit.ak
+++ b/lib/calculation/deposit.ak
@@ -93,6 +93,9 @@ pub fn do_deposit(
   let issued_lp_tokens =
     deposited_a * pool_state.quantity_lp.3rd / pool_state.quantity_a.3rd
 
+  // Make sure we don't ever allow this to round to zero, which would just eat some of the users assets
+  expect issued_lp_tokens > 0
+
   // Calculate what assets we expect on at the destination;
   // i.e. it should be whatever assets were on the inputs, minus the amount that was deposited, minus the fee,
   // plus the relevant LP tokens

--- a/lib/tests/aiken/deposit.ak
+++ b/lib/tests/aiken/deposit.ak
@@ -21,6 +21,18 @@ test deposit_test() {
   )
 }
 
+test deposit_test_minimum() fail {
+  deposit_test_schema(
+    661_278_808_416,
+    188_253_559_159_646,
+    153_000_000,
+    150,
+    151_171_875,
+    150,
+    value.from_lovelace(152_000_000)
+  )
+}
+
 fn deposit_test_schema(qa: Int, qb: Int, has_a: Int, has_b: Int, gives_a: Int, gives_b: Int, out_value: value.Value) {
   let addr =
     Address(
@@ -80,4 +92,3 @@ fn deposit_test_schema(qa: Int, qb: Int, has_a: Int, has_b: Int, gives_a: Int, g
   // Test should pass as long as do_deposit didn't throw
   True
 }
-


### PR DESCRIPTION
If the received LP tokens rounds to zero, we should fail the transaction, so the user doesn't lose their assets