### PR TITLE
Fix the `ok_scoop_swap_swap` test in the stableswap branch

### DIFF
--- a/aiken.lock
+++ b/aiken.lock
@@ -35,4 +35,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/stdlib@v2" = [{ secs_since_epoch = 1742191004, nanos_since_epoch = 527078615 }, "25c8d0802b8266feca04b47933382c5dee3cadb422208a5d3810d9d2df108c2e"]
+"aiken-lang/stdlib@v2" = [{ secs_since_epoch = 1743968370, nanos_since_epoch = 719258000 }, "25c8d0802b8266feca04b47933382c5dee3cadb422208a5d3810d9d2df108c2e"]

--- a/lib/calculation/process.ak
+++ b/lib/calculation/process.ak
@@ -534,7 +534,8 @@ pub fn process_orders(
         simple_fee,
         strategy_fee,
         linear_amplification,
-        sum_invariant,
+        // In the next swap, the current new_sum_invariant becomes the old_sum_invariant
+        new_sum_invariant,
         idx + 1,
         // This is the "previous index" within the input list; TODO: I'm not actually sure why we add 1?
         all_inputs,

--- a/lib/calculation/stableswap.ak
+++ b/lib/calculation/stableswap.ak
@@ -15,7 +15,7 @@ pub fn swap_invariant(
     ),
     exchange_invariant(
       new_pool_gives,
-      new_pool_takes - takes_fees,
+      new_pool_takes - takes_fees - 1,
       linear_amplification,
       old_sum_invariant,
     ),
@@ -29,8 +29,8 @@ pub fn liquidity_invariant(
   new_sum_invariant: Int,
 ) {
   // 4 * A * 4 * (x*y) * D + D^3 - (4(x*y) * (4A(x + y) + D))
-  // 4A * 4xy * D + D^3 - (4xy * 4a * (x + y) + D)
-  // 16Axy * D + D^3 - (16Axy * (x + y) + D)
+  // 4A * 4xy * D + D^3 - (4xy * 4a * (x + y) + 4xy * D)
+  // 16Axy * D + D^3 - (16Axy * (x + y) + 4xy * D)
   let four_a = 4 * linear_amplification
   let four_x_y = 4 * new_pool_gives * new_pool_takes
   let d_plus_one = new_sum_invariant + 1
@@ -40,9 +40,13 @@ pub fn liquidity_invariant(
   let sixteen_a_x_y = four_a * four_x_y
   let sixteen_a_x_y_x_plus_y = sixteen_a_x_y * x_plus_y
   let f1 =
-    sixteen_a_x_y * new_sum_invariant + d_cubed - (sixteen_a_x_y_x_plus_y + new_sum_invariant)
+    sixteen_a_x_y * new_sum_invariant + d_cubed - (
+      sixteen_a_x_y_x_plus_y + four_x_y * new_sum_invariant
+    )
   let f2 =
-    sixteen_a_x_y * d_plus_one + d_plus_one_cubed - (sixteen_a_x_y_x_plus_y + d_plus_one)
+    sixteen_a_x_y * d_plus_one + d_plus_one_cubed - (
+      sixteen_a_x_y_x_plus_y + four_x_y * d_plus_one
+    )
   and {
     f1 <= 0,
     f2 > 0,

--- a/lib/calculation/swap.ak
+++ b/lib/calculation/swap.ak
@@ -144,8 +144,18 @@ pub fn do_swap(
   let swap_result = order_takes * 10000 / difference
 
   let total_fees = swap_result - order_takes
-  let lp_fees = total_fees * lp_fee_rate / total_fee_rate
-  let protocol_fees = total_fees * protocol_fee_rate / total_fee_rate
+  let lp_fees =
+    if total_fee_rate > 0 {
+      total_fees * lp_fee_rate / total_fee_rate
+    } else {
+      0
+    }
+  let protocol_fees =
+    if total_fee_rate > 0 {
+      total_fees * protocol_fee_rate / total_fee_rate
+    } else {
+      0
+    }
 
   // Note: the protocol_fees aren't taken by the user, but are "taken out" of the pool
   let pool_deduction = order_takes + protocol_fees
@@ -164,7 +174,12 @@ pub fn do_swap(
         sum_invariant,
         next_sum_invariant,
       )
-    continuation(pool_quantity_a + order_give, pool_quantity_b - pool_deduction, 0, protocol_fees)
+    continuation(
+      pool_quantity_a + order_give,
+      pool_quantity_b - pool_deduction,
+      0,
+      protocol_fees,
+    )
   } else {
     expect
       stableswap.swap_invariant(
@@ -175,6 +190,11 @@ pub fn do_swap(
         sum_invariant,
         next_sum_invariant,
       )
-    continuation(pool_quantity_a - pool_deduction, pool_quantity_b + order_give, protocol_fees, 0)
+    continuation(
+      pool_quantity_a - pool_deduction,
+      pool_quantity_b + order_give,
+      protocol_fees,
+      0,
+    )
   }
 }

--- a/validators/tests/pool.ak
+++ b/validators/tests/pool.ak
@@ -350,8 +350,8 @@ fn scoop(options: ScoopTestOptions) {
       fee_manager: None,
       market_open: 0,
       protocol_fees: (2_000_000, 0, 0),
-      linear_amplification: 0,
-      sum_invariant: 1,
+      linear_amplification: 200,
+      sum_invariant: 2000000000,
     }
   let pool_out_datum =
     StablePoolDatum {
@@ -366,8 +366,8 @@ fn scoop(options: ScoopTestOptions) {
       fee_manager: None,
       market_open: 0,
       protocol_fees: (7_000_000, 0, 0),
-      linear_amplification: 0,
-      sum_invariant: 1,
+      linear_amplification: 200,
+      sum_invariant: 2000010000,
     }
   let pool_nft_name = shared.pool_nft_name(constants.pool_ident)
   let pool_address = script_address(constants.pool_script_hash)
@@ -481,7 +481,7 @@ fn scoop(options: ScoopTestOptions) {
           |> assets.add(
               constants.rberry_policy,
               constants.rberry_asset_name,
-              9_896_088,
+              9_994_750,
             ),
       ),
       datum: order1_out_datum,
@@ -503,7 +503,7 @@ fn scoop(options: ScoopTestOptions) {
           |> assets.add(
               constants.rberry_policy,
               constants.rberry_asset_name,
-              9_702_095,
+              9_994_252,
             ),
       ),
       datum: order2_out_datum,
@@ -518,7 +518,7 @@ fn scoop(options: ScoopTestOptions) {
           |> assets.add(
               constants.rberry_policy,
               constants.rberry_asset_name,
-              1_000_000_000 - ( 9_896_088 + 9_702_095 ),
+              1_000_000_000 - ( 9_994_750 + 9_994_252 ),
             )
           |> assets.add(constants.pool_script_hash, pool_nft_name, 1),
       ),
@@ -536,7 +536,8 @@ fn scoop(options: ScoopTestOptions) {
       extra_signatories: [constants.scooper],
       id: mk_tx_hash(1),
     }
-  let pool_redeemer = PoolScoop(0, 0, [(1, None, 1), (2, None, 1)])
+  let pool_redeemer =
+    PoolScoop(0, 0, [(1, None, 2_000_005_000), (2, None, 2_000_010_000)])
   let result =
     pool_validator.pool.spend(
       constants.manage_stake_script_hash,


### PR DESCRIPTION
Proposed fixes to get the `ok_scoop_swap_swap` test to pass in the stableswap branch