### PR TITLE
Pi/tx fee from protocol fee

### DIFF
--- a/aiken.lock
+++ b/aiken.lock
@@ -46,4 +46,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/fuzz@main" = [{ secs_since_epoch = 1759752657, nanos_since_epoch = 254837324 }, "9843473958e51725a9274b487d2d4aac0395ec1a2e30f090724fa737226bc127"]
+"aiken-lang/fuzz@main" = [{ secs_since_epoch = 1765208767, nanos_since_epoch = 316606729 }, "9843473958e51725a9274b487d2d4aac0395ec1a2e30f090724fa737226bc127"]

--- a/validators/pool.ak
+++ b/validators/pool.ak
@@ -250,12 +250,14 @@ validator pool(
         // We multiply amortized_base_fee, which everyone paid, by the number of orders
         // and then the respective fees for each simple order and strategy order
         let expected_fees_collected =
-          amortized_base_fee * real_order_count + simple_count * simple_fee + strategy_count * strategy_fee
+          amortized_base_fee * real_order_count + simple_count * simple_fee + strategy_count * strategy_fee - fee
+
+        expect expected_fees_collected >= 0
 
         // Make sure we actually increased the protocol fee by exactly this amount
         let expected_protocol_fees =
           (
-            initial_fee_ada + expected_fees_collected - fee,
+            initial_fee_ada + expected_fees_collected,
             initial_fee_a + delta_fee_a,
             initial_fee_b + delta_fee_b,
           )
@@ -993,7 +995,7 @@ validator manage(settings_policy_id: PolicyId) {
               datum.protocol_fees.2nd,
               datum.protocol_fees.3rd,
             ),
-            lp_fee_basis_points: lp_fee_basis_points,
+            lp_fee_basis_points,
             fee_manager: output_fee_manager,
           }
         pool_output_datum == expected_datum
@@ -1056,8 +1058,8 @@ validator manage(settings_policy_id: PolicyId) {
               datum.protocol_fees.2nd,
               datum.protocol_fees.3rd,
             ),
-            linear_amplification: linear_amplification,
-            sum_invariant: sum_invariant,
+            linear_amplification,
+            sum_invariant,
             linear_amplification_manager: output_linear_amplification_manager,
           }
         pool_output_datum == expected_datum

--- a/validators/pool.ak
+++ b/validators/pool.ak
@@ -68,6 +68,7 @@ validator pool(
       extra_signatories,
       validity_range,
       withdrawals,
+      fee,
       ..
     } = transaction
 
@@ -254,7 +255,7 @@ validator pool(
         // Make sure we actually increased the protocol fee by exactly this amount
         let expected_protocol_fees =
           (
-            initial_fee_ada + expected_fees_collected,
+            initial_fee_ada + expected_fees_collected - fee,
             initial_fee_a + delta_fee_a,
             initial_fee_b + delta_fee_b,
           )

--- a/validators/tests/pool.ak
+++ b/validators/tests/pool.ak
@@ -36,9 +36,7 @@ use types/pool.{
   BurnPool, CreatePool, Manage, PoolMintRedeemer, PoolScoop, StablePoolDatum,
   UpdatePoolFees, WithdrawFees,
 }
-use types/settings.{
-  SettingsDatum, settings_nft_name,
-}
+use types/settings.{SettingsDatum, settings_nft_name}
 
 type ScoopTestOptions {
   edit_order_1_in_value: Option<Value>,
@@ -106,7 +104,8 @@ test ok_scoop_swap_protocol_fees() {
     ScoopTestOptions {
       ..default_scoop_test_options(),
       edit_protocol_fee_basis_points: Some((10, 10)),
-      edit_accrued_protocol_fees: Some((7_000_000 - 600_000, 0, 19_999)), // Subtract off tx_fee here
+      edit_accrued_protocol_fees: Some((7_000_000 - 600_000, 0, 19_999)),
+      // Subtract off tx_fee here
       edit_order_1_out_value: Some(
         assets.from_lovelace(2_000_000)
           |> assets.add(
@@ -124,7 +123,9 @@ test ok_scoop_swap_protocol_fees() {
             ),
       ),
       edit_pool_output_value: Some(
-        assets.from_lovelace(1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000 - 600_000)
+        assets.from_lovelace(
+          1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000 - 600_000,
+        )
           |> assets.add(
               constants.rberry_policy,
               constants.rberry_asset_name,
@@ -183,8 +184,9 @@ test ok_scoop_swap_with_over_rounding() {
       ),
       edit_pool_output_value: Some(
         assets.from_lovelace(
-          amt_1 + amt_2 + 20_000_000_000 + 2_000_000 + 2_500_000 + 2_500_000 - 600_000, // subtract off the tx_fee
+          amt_1 + amt_2 + 20_000_000_000 + 2_000_000 + 2_500_000 + 2_500_000 - 600_000,
         )
+          // subtract off the tx_fee
           |> assets.add(
               constants.rberry_policy,
               constants.rberry_asset_name,
@@ -257,7 +259,16 @@ test pool_validator_ignores_fee() {
   let options =
     ScoopTestOptions {
       ..default_scoop_test_options(),
-      edit_fee: Some(1_000_000_000),
+      edit_fee: Some(1_000_000),
+    }
+  scoop(options)
+}
+
+test pool_validator_fails_fee_too_high() fail {
+  let options =
+    ScoopTestOptions {
+      ..default_scoop_test_options(),
+      edit_fee: Some(5_000_001),
     }
   scoop(options)
 }
@@ -286,7 +297,10 @@ test scoop_high_swap_fees() {
             ),
       ),
       edit_pool_output_value: Some(
-        assets.from_lovelace(1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000 - 600_000) // subtract off tx_fee
+        assets.from_lovelace(
+          1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000 - 600_000,
+        )
+          // subtract off tx_fee
           |> assets.add(
               constants.rberry_policy,
               constants.rberry_asset_name,
@@ -399,7 +413,10 @@ fn scoop(options: ScoopTestOptions) {
     option.or_else(options.edit_protocol_fee_basis_points, (0, 0))
   let tx_fee = option.or_else(options.edit_fee, 600_000)
   let accrued_protocol_fees =
-    option.or_else(options.edit_accrued_protocol_fees, (7_000_000 - tx_fee, 0, 0))
+    option.or_else(
+      options.edit_accrued_protocol_fees,
+      (7_000_000 - tx_fee, 0, 0),
+    )
   let sum_invariants =
     option.or_else(
       options.edit_sum_invariants,
@@ -592,7 +609,9 @@ fn scoop(options: ScoopTestOptions) {
       address: option.or_else(options.edit_pool_output_address, pool_address),
       value: option.or_else(
         options.edit_pool_output_value,
-        assets.from_lovelace(1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000 - tx_fee)
+        assets.from_lovelace(
+          1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000 - tx_fee,
+        )
           |> assets.add(
               constants.rberry_policy,
               constants.rberry_asset_name,
@@ -813,7 +832,9 @@ fn scoop_swap_deposit(options: ScoopTestOptions) {
       address: pool_address,
       value: option.or_else(
         options.edit_pool_output_value,
-        assets.from_lovelace(1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000 - tx_fee)
+        assets.from_lovelace(
+          1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000 - tx_fee,
+        )
           |> assets.add(
               constants.rberry_policy,
               constants.rberry_asset_name,
@@ -1229,7 +1250,7 @@ fn update_pool_fees_transaction(options: ScoopTestOptions) {
   let ctx =
     ScriptContext {
       ..ctx,
-      transaction: Transaction { ..ctx.transaction, withdrawals: withdrawals },
+      transaction: Transaction { ..ctx.transaction, withdrawals },
       redeemer: update_fees_redeemer,
     }
 

--- a/validators/tests/pool.ak
+++ b/validators/tests/pool.ak
@@ -106,7 +106,7 @@ test ok_scoop_swap_protocol_fees() {
     ScoopTestOptions {
       ..default_scoop_test_options(),
       edit_protocol_fee_basis_points: Some((10, 10)),
-      edit_accrued_protocol_fees: Some((7_000_000, 0, 19_999)),
+      edit_accrued_protocol_fees: Some((7_000_000 - 600_000, 0, 19_999)), // Subtract off tx_fee here
       edit_order_1_out_value: Some(
         assets.from_lovelace(2_000_000)
           |> assets.add(
@@ -124,7 +124,7 @@ test ok_scoop_swap_protocol_fees() {
             ),
       ),
       edit_pool_output_value: Some(
-        assets.from_lovelace(1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000)
+        assets.from_lovelace(1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000 - 600_000)
           |> assets.add(
               constants.rberry_policy,
               constants.rberry_asset_name,
@@ -183,7 +183,7 @@ test ok_scoop_swap_with_over_rounding() {
       ),
       edit_pool_output_value: Some(
         assets.from_lovelace(
-          amt_1 + amt_2 + 20_000_000_000 + 2_000_000 + 2_500_000 + 2_500_000,
+          amt_1 + amt_2 + 20_000_000_000 + 2_000_000 + 2_500_000 + 2_500_000 - 600_000, // subtract off the tx_fee
         )
           |> assets.add(
               constants.rberry_policy,
@@ -286,7 +286,7 @@ test scoop_high_swap_fees() {
             ),
       ),
       edit_pool_output_value: Some(
-        assets.from_lovelace(1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000)
+        assets.from_lovelace(1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000 - 600_000) // subtract off tx_fee
           |> assets.add(
               constants.rberry_policy,
               constants.rberry_asset_name,
@@ -397,8 +397,9 @@ fn scoop(options: ScoopTestOptions) {
   let fees = option.or_else(options.edit_swap_fees, (5, 5))
   let protocol_fee_basis_points =
     option.or_else(options.edit_protocol_fee_basis_points, (0, 0))
+  let tx_fee = option.or_else(options.edit_fee, 600_000)
   let accrued_protocol_fees =
-    option.or_else(options.edit_accrued_protocol_fees, (7_000_000, 0, 0))
+    option.or_else(options.edit_accrued_protocol_fees, (7_000_000 - tx_fee, 0, 0))
   let sum_invariants =
     option.or_else(
       options.edit_sum_invariants,
@@ -591,7 +592,7 @@ fn scoop(options: ScoopTestOptions) {
       address: option.or_else(options.edit_pool_output_address, pool_address),
       value: option.or_else(
         options.edit_pool_output_value,
-        assets.from_lovelace(1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000)
+        assets.from_lovelace(1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000 - tx_fee)
           |> assets.add(
               constants.rberry_policy,
               constants.rberry_asset_name,
@@ -608,7 +609,7 @@ fn scoop(options: ScoopTestOptions) {
       inputs: [pool_input, order1_in, order2_in],
       reference_inputs: [settings_input],
       outputs: [pool_output, order1_out, order2_out],
-      fee: option.or_else(options.edit_fee, 1_000_000),
+      fee: tx_fee,
       validity_range: interval.between(1, 2),
       extra_signatories: [constants.scooper],
       id: mk_tx_hash(1),
@@ -663,6 +664,7 @@ fn scoop_swap_deposit(options: ScoopTestOptions) {
         2000000000000000000000,
       ),
     }
+  let tx_fee = option.or_else(options.edit_fee, 600_000)
   let pool_out_datum =
     StablePoolDatum {
       identifier: constants.pool_ident,
@@ -675,7 +677,7 @@ fn scoop_swap_deposit(options: ScoopTestOptions) {
       protocol_fee_basis_points: (0, 0),
       fee_manager: None,
       market_open: 0,
-      protocol_fees: (7_000_000, 0, 0),
+      protocol_fees: (7_000_000 - tx_fee, 0, 0),
       linear_amplification: 200,
       linear_amplification_manager: None,
       sum_invariant: sum_invariants.2nd,
@@ -811,7 +813,7 @@ fn scoop_swap_deposit(options: ScoopTestOptions) {
       address: pool_address,
       value: option.or_else(
         options.edit_pool_output_value,
-        assets.from_lovelace(1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000)
+        assets.from_lovelace(1_000_000_000 + 20_000_000 + 5_000_000 + 2_000_000 - tx_fee)
           |> assets.add(
               constants.rberry_policy,
               constants.rberry_asset_name,
@@ -829,7 +831,7 @@ fn scoop_swap_deposit(options: ScoopTestOptions) {
       inputs: [pool_input, order1_in, order2_in],
       reference_inputs: [settings_input],
       outputs: [pool_output, order1_out, order2_out],
-      fee: option.or_else(options.edit_fee, 1_000_000),
+      fee: tx_fee,
       mint: assets.zero
         |> assets.add(
             constants.pool_script_hash,


### PR DESCRIPTION
Without this change, the scoopers have to float the cost of the transaction until they get reimbursed at the end of the month;

With this, the scooper is allowed to pay that fee *out* of the collected protocol fee, removing the upfront cost of executing a scoop.